### PR TITLE
fix(spec): correct Appendix C test vector hash (Issue #18)

### DIFF
--- a/spec/did-method-trail-v1.md
+++ b/spec/did-method-trail-v1.md
@@ -2147,9 +2147,9 @@ Output: did:trail:self:z3KMQXnVKR9qMzkJFfoo9WAYb1A7rdUbEkDCwNWTp6uJX
 Input:            "ACME Corporation GmbH"
 Normalized slug:  "acme"
 Hash input:       "acme:z3KMQXnVKR9qMzkJFfoo9WAYb1A7rdUbEkDCwNWTp6uJX"
-SHA-256 (hex):    bd70674e4dff8c3a...
-trail-hash:       "bd70674e4dff8c3a"
-Output DID:       did:trail:org:acme-bd70674e4dff8c3a
+SHA-256 (hex):    bd70674e4dffef6e1a54de8b4b78b9fe140f638dfc5b21a239eb48950cc60758
+trail-hash:       "bd70674e4dffef6e"
+Output DID:       did:trail:org:acme-bd70674e4dffef6e
 ```
 
 ### 14.4 JCS Canonicalization (RFC 8785)

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -94,12 +94,6 @@ These vectors target spec **v1.2.0** (current draft). If you find a vector that
 disagrees with a published normative statement of the spec, please open an
 issue — the spec is authoritative, the suite is illustrative.
 
-> Known follow-up: Appendix C v1.2.0 shows a truncated/illustrative SHA-256
-> example for the org-mode trail-hash; the actual SHA-256 of the documented
-> hash input begins `bd70674e4dffef6e…`. The vector at
-> `did-creation/valid/02-org-mode-slug-hash.json` uses the actual hash; a spec
-> issue will be filed to align Appendix C.
-
 ## Adding New Vectors
 
 1. Place a new JSON file under the appropriate scope and `valid/` or `invalid/`

--- a/tests/conformance/did-creation/invalid/01-wrong-method-name.json
+++ b/tests/conformance/did-creation/invalid/01-wrong-method-name.json
@@ -4,7 +4,7 @@
   "expected": "invalid",
   "description": "DIDs MUST start with 'did:trail:'. Any other method prefix (or wrong casing) MUST be rejected.",
   "input": {
-    "did": "did:Trail:org:acme-bd70674e4dff8c3a"
+    "did": "did:Trail:org:acme-bd70674e4dffef6e"
   },
   "expectedError": "DID method name MUST be exactly 'did:trail:' (case-sensitive)"
 }

--- a/tests/conformance/did-creation/valid/02-org-mode-slug-hash.json
+++ b/tests/conformance/did-creation/valid/02-org-mode-slug-hash.json
@@ -2,7 +2,7 @@
   "scope": "did-creation",
   "section": "§4.2 org mode + §4.5 normalization",
   "expected": "valid",
-  "description": "Org-mode DID with slug normalization (lowercase, drop legal suffixes) and 16-hex trail-hash suffix derived from SHA-256 of normalized slug + publicKeyMultibase. NOTE: Spec Appendix C v1.2.0 shows truncated hash 'bd70674e4dff8c3a...' which appears to be illustrative; actual SHA-256 of the documented hash input starts with 'bd70674e4dffef6e'. Filed as spec follow-up.",
+  "description": "Org-mode DID with slug normalization (lowercase, drop legal suffixes) and 16-hex trail-hash suffix derived from SHA-256 of normalized slug + publicKeyMultibase. Matches Appendix C §14.3 test vector (Issue #18).",
   "input": {
     "mode": "org",
     "rawName": "ACME Corporation GmbH",


### PR DESCRIPTION
## Summary
Fixes #18 — Appendix C (§14.3) `trail-hash` example used an illustrative placeholder. Recomputed SHA-256 and corrected the truncated hash and the resulting DID so the test vector is reproducible end-to-end.

## Changes
- `bd70674e4dff8c3a` → `bd70674e4dffef6e` (and the corresponding `acme-...` DID)
- Files touched:
  - `spec/did-method-trail-v1.md` — Appendix C §14.3 (hash full digest, truncated hash, output DID)
  - `tests/conformance/did-creation/valid/02-org-mode-slug-hash.json` — description note simplified (issue resolved)
  - `tests/conformance/did-creation/invalid/01-wrong-method-name.json` — DID example aligned to corrected hash
  - `tests/conformance/README.md` — "Known follow-up" note removed (issue resolved)

## Verification
```bash
node -e "console.log(require('crypto').createHash('sha256').update('acme:z3KMQXnVKR9qMzkJFfoo9WAYb1A7rdUbEkDCwNWTp6uJX').digest('hex'))"
# bd70674e4dffef6e1a54de8b4b78b9fe140f638dfc5b21a239eb48950cc60758
```

Conformance harness locally green (16/16):
```
node tests/conformance/harness.mjs
# === Summary ===
# Pass: 16
# Fail: 0
```

Closes #18