### PR TITLE
fix(spec): correct header version to 1.2.1

### DIFF
--- a/spec/did-method-trail-v1.md
+++ b/spec/did-method-trail-v1.md
@@ -1,11 +1,11 @@
 # did:trail Method Specification
 
-**Version:** 1.2.0-draft
+**Version:** 1.2.1
 **Status:** Draft
 **Authors:** Christian Hommrich (TRAIL Protocol Initiative)
 **Contact:** christian.hommrich@trailprotocol.org
 **Repository:** https://github.com/trailprotocol/trail-did-method
-**Date:** 2026-03-04
+**Date:** 2026-04-22
 **License:** CC BY 4.0
 
 ---
@@ -2237,6 +2237,14 @@ The `OutputAttestationVC` is protocol-agnostic. It can be issued regardless of h
 ---
 
 ## 16. Changelog
+
+### v1.2.1 (2026-04-22)
+
+Editorial patch release. No behavioral change for implementations.
+
+| # | Change | Sections Affected |
+|---|--------|-------------------|
+| 1 | **Aligned trail-hash reference in §6.3 with the normative definition in §4.5.2** — §6.3 (Hash and Key Rotation Semantics) still referenced `[0:12]`, a leftover from v1.1.0-draft before the 48-bit to 64-bit change. The normative definition in §4.5.2 already used `[0:16]` (16 hex characters, 64 bits) correctly. This patch removes the stale reference. | §6.3 |
 
 ### v1.2.0 (2026-04-21)
 


### PR DESCRIPTION
## Summary
Corrects the spec header, which still read `1.2.0-draft` even though v1.2.0 and v1.2.1 are tagged releases. A `-draft` suffix on a released version is misleading for anyone reading the spec linked from the project site.

## Changes
- Header version `1.2.0-draft` to `1.2.1` (latest tagged release)
- Header date aligned to the v1.2.1 release date (2026-04-22)
- Added the missing v1.2.1 changelog entry (the editorial trail-hash reference fix in 6.3 that the tag shipped)

## Rationale for the version number
All method-spec commits since the v1.2.1 tag are editorial (`chore`/`docs`: contact-email alignment, roadmap status refresh). Per the SemVer policy in 8.10, editorial changes do not warrant a minor or major bump, so `1.2.1` is correct for the current state.

## Deliberately unchanged
`Status: Draft` stays. This is a W3C Community Group specification, not a ratified standard, so the maturity label is accurate.

## Verification
`git log v1.2.1..main -- spec/did-method-trail-v1.md` shows only chore/docs commits since the tag.