### PR TITLE
feat(trail-core): implement BindingProofCredential (§5.4.5)

### DIFF
--- a/packages/trail-core/src/credential.ts
+++ b/packages/trail-core/src/credential.ts
@@ -1,5 +1,11 @@
 import { createProof, verifyProof } from './proof';
-import type { VerifiableCredential, DataIntegrityProof } from './types';
+import type {
+  VerifiableCredential,
+  DataIntegrityProof,
+  BindingProofCredential,
+  StatusList2021Entry,
+  DidDocument,
+} from './types';
 
 /**
  * Create a self-signed Verifiable Credential.
@@ -85,4 +91,299 @@ export function verifyCredential(
     valid: errors.length === 0,
     errors,
   };
+}
+
+// ---------------------------------------------------------------------------
+// BindingProofCredential (spec §5.4.5)
+// ---------------------------------------------------------------------------
+
+const VC_V2_CONTEXT = 'https://www.w3.org/ns/credentials/v2';
+const TRAIL_CREDENTIALS_V2_CONTEXT = 'https://trailprotocol.org/ns/credentials/v2';
+
+export interface CreateBindingProofOptions {
+  /** DID signing (and asserting) this leg. Becomes issuer and binding.from. */
+  issuerDid: string;
+  /** Counterpart DID being bound to. Becomes credentialSubject.id and binding.to. */
+  subjectDid: string;
+  /** Ed25519 private key of the issuer. */
+  privateKeyBytes: Uint8Array;
+  /** StatusList2021 entry on the issuer's own status list (§8.7). */
+  credentialStatus: StatusList2021Entry;
+  /** ISO 8601 validity start. */
+  validFrom: string;
+  /** ISO 8601 validity end. SHOULD NOT exceed 12 months after validFrom. */
+  validUntil: string;
+  /** ISO 8601 attestation time. Defaults to validFrom if omitted. */
+  boundAt?: string;
+  /** Verification method fragment on the issuer DID. Defaults to '#key-1'. */
+  keyFragment?: string;
+}
+
+/**
+ * Create one leg of a BindingProofCredential (§5.4.5).
+ *
+ * Produces a single outbound credential from the issuer's perspective:
+ * `binding.from == issuer` and `binding.to == credentialSubject.id`.
+ * A verified cross-method binding requires TWO of these — one signed by
+ * each controller — which is the caller's responsibility to assemble.
+ */
+export function createBindingProofCredential(
+  options: CreateBindingProofOptions
+): BindingProofCredential {
+  const boundAt = options.boundAt ?? options.validFrom;
+  const keyFragment = options.keyFragment ?? '#key-1';
+
+  const vc: Omit<BindingProofCredential, 'proof'> = {
+    '@context': [VC_V2_CONTEXT, TRAIL_CREDENTIALS_V2_CONTEXT],
+    type: ['VerifiableCredential', 'BindingProofCredential'],
+    issuer: options.issuerDid,
+    validFrom: options.validFrom,
+    validUntil: options.validUntil,
+    credentialSubject: {
+      id: options.subjectDid,
+      binding: {
+        from: options.issuerDid,
+        to: options.subjectDid,
+        boundAt,
+      },
+    },
+    credentialStatus: options.credentialStatus,
+  };
+
+  const proof = createProof(
+    vc,
+    options.privateKeyBytes,
+    `${options.issuerDid}${keyFragment}`,
+    'assertionMethod'
+  );
+
+  return { ...vc, proof };
+}
+
+/**
+ * Inputs a caller must supply to verify a binding. Because trail-core does no
+ * network IO, DID resolution and StatusList fetching are the caller's job
+ * (consistent with the §5.4.5.3 verifier steps): the caller resolves both DID
+ * Documents, extracts the signing public keys, and determines revocation state,
+ * then passes the results here.
+ */
+export interface VerifyBindingProofInput {
+  /** BindingProofCredential issued by the did:trail controller. */
+  trailCredential: BindingProofCredential;
+  /** Reciprocal BindingProofCredential issued by the foreign DID controller. */
+  foreignCredential: BindingProofCredential;
+  /** Resolved DID Document of the did:trail side. */
+  trailDidDocument: DidDocument;
+  /** Resolved DID Document of the foreign side. */
+  foreignDidDocument: DidDocument;
+  /** Ed25519 public key that signed trailCredential. */
+  trailPublicKeyBytes: Uint8Array;
+  /** Ed25519 public key that signed foreignCredential. */
+  foreignPublicKeyBytes: Uint8Array;
+  /**
+   * Revocation state, determined by the caller from each issuer's StatusList
+   * (§5.4.5.3 step 7 / §5.4.5.5). trail-core does not fetch status lists.
+   */
+  revocation: {
+    trailCredentialRevoked: boolean;
+    foreignCredentialRevoked: boolean;
+  };
+  /**
+   * Signing-key revocation state at verification time (§5.4.5.3 step 5).
+   * The stricter "key active at boundAt" check is deferred per the spec;
+   * this is the scoped-down "not revoked now" check. Defaults to
+   * { trail: false, foreign: false } when omitted.
+   */
+  keyRevocation?: {
+    trailSigningKeyRevoked: boolean;
+    foreignSigningKeyRevoked: boolean;
+  };
+  /** Verification-time instant (ISO 8601). Defaults to now. Used for the validity window. */
+  now?: string;
+}
+
+export interface BindingProofVerificationResult {
+  /** True only if the binding is cryptographically verified per all §5.4.5.3 steps. */
+  verified: boolean;
+  /** Human-readable failure reasons, keyed loosely to the §5.4.5.3 step that failed. */
+  errors: string[];
+}
+
+/**
+ * Verify a cross-method binding is cryptographically verified per §5.4.5.3.
+ *
+ * Pure function: no network IO. The caller resolves DID Documents, extracts
+ * signing keys, and supplies revocation state. Returns `verified: true` only
+ * when every applicable step passes for BOTH reciprocal credentials.
+ *
+ * Note on the §5.4.2 alsoKnownAs precondition (step 1): this function checks
+ * the bidirectional alsoKnownAs references on the two supplied DID Documents.
+ * The stricter "key was active at boundAt" part of step 5 is deferred per the
+ * spec; boundAt is validated for shape but not used as a point-in-time key
+ * check.
+ */
+export function verifyBindingProof(
+  input: VerifyBindingProofInput
+): BindingProofVerificationResult {
+  const errors: string[] = [];
+  const now = input.now ?? new Date().toISOString();
+  const keyRevocation = input.keyRevocation ?? {
+    trailSigningKeyRevoked: false,
+    foreignSigningKeyRevoked: false,
+  };
+
+  const trailDid = input.trailDidDocument.id;
+  const foreignDid = input.foreignDidDocument.id;
+
+  // Step 1 — §5.4.2 bidirectional alsoKnownAs on both DID Documents.
+  const trailAka = input.trailDidDocument.alsoKnownAs ?? [];
+  const foreignAka = input.foreignDidDocument.alsoKnownAs ?? [];
+  if (!trailAka.includes(foreignDid)) {
+    errors.push(
+      `Step 1: did:trail document does not list foreign DID in alsoKnownAs (${foreignDid})`
+    );
+  }
+  if (!foreignAka.includes(trailDid)) {
+    errors.push(
+      `Step 1: foreign document does not list did:trail DID in alsoKnownAs (${trailDid})`
+    );
+  }
+
+  // Steps 2 & 3 — reciprocal credentials exist with correct issuer/binding orientation.
+  const t = input.trailCredential;
+  const f = input.foreignCredential;
+
+  if (!isBindingProofShape(t)) {
+    errors.push('Step 2: trailCredential is not a well-formed BindingProofCredential');
+  }
+  if (!isBindingProofShape(f)) {
+    errors.push('Step 3: foreignCredential is not a well-formed BindingProofCredential');
+  }
+
+  // Only continue orientation checks if the basic shape held, to avoid
+  // dereferencing undefined fields.
+  if (isBindingProofShape(t)) {
+    // trail leg: issuer == trailDid, binding.from == issuer, binding.to == foreignDid
+    if (t.issuer !== trailDid) {
+      errors.push(`Step 2: trailCredential.issuer (${t.issuer}) does not match resolved did:trail DID (${trailDid})`);
+    }
+    if (t.credentialSubject.binding.from !== t.issuer) {
+      errors.push('Step 2: trailCredential binding.from does not equal issuer');
+    }
+    if (t.credentialSubject.id !== t.credentialSubject.binding.to) {
+      errors.push('Step 2: trailCredential credentialSubject.id does not equal binding.to');
+    }
+    if (t.credentialSubject.binding.to !== foreignDid) {
+      errors.push(`Step 2: trailCredential binding.to (${t.credentialSubject.binding.to}) does not match foreign DID (${foreignDid})`);
+    }
+  }
+
+  if (isBindingProofShape(f)) {
+    if (f.issuer !== foreignDid) {
+      errors.push(`Step 3: foreignCredential.issuer (${f.issuer}) does not match resolved foreign DID (${foreignDid})`);
+    }
+    if (f.credentialSubject.binding.from !== f.issuer) {
+      errors.push('Step 3: foreignCredential binding.from does not equal issuer');
+    }
+    if (f.credentialSubject.id !== f.credentialSubject.binding.to) {
+      errors.push('Step 3: foreignCredential credentialSubject.id does not equal binding.to');
+    }
+    if (f.credentialSubject.binding.to !== trailDid) {
+      errors.push(`Step 3: foreignCredential binding.to (${f.credentialSubject.binding.to}) does not match did:trail DID (${trailDid})`);
+    }
+  }
+
+  // Step 4 — proofs verify against a key in the issuer's assertionMethod set.
+  // We check both that the verificationMethod is listed in assertionMethod AND
+  // that the signature verifies against the supplied public key.
+  verifyLegProof(t, input.trailDidDocument, input.trailPublicKeyBytes, 'Step 4 (trail)', errors);
+  verifyLegProof(f, input.foreignDidDocument, input.foreignPublicKeyBytes, 'Step 4 (foreign)', errors);
+
+  // Step 5 — signing key not revoked at verification time (scoped; "active at
+  // boundAt" deferred per spec).
+  if (keyRevocation.trailSigningKeyRevoked) {
+    errors.push('Step 5: trail signing key is revoked at verification time');
+  }
+  if (keyRevocation.foreignSigningKeyRevoked) {
+    errors.push('Step 5: foreign signing key is revoked at verification time');
+  }
+
+  // Step 6 — both credentials within validFrom / validUntil at `now`.
+  checkValidityWindow(t, now, 'Step 6 (trail)', errors);
+  checkValidityWindow(f, now, 'Step 6 (foreign)', errors);
+
+  // Step 7 — neither credential revoked per its credentialStatus.
+  if (input.revocation.trailCredentialRevoked) {
+    errors.push('Step 7: trailCredential is revoked per its credentialStatus');
+  }
+  if (input.revocation.foreignCredentialRevoked) {
+    errors.push('Step 7: foreignCredential is revoked per its credentialStatus');
+  }
+
+  return { verified: errors.length === 0, errors };
+}
+
+/** Structural guard: does this object have the required BindingProofCredential shape? */
+function isBindingProofShape(vc: VerifiableCredential): vc is BindingProofCredential {
+  const cs = vc.credentialSubject as Record<string, unknown> | undefined;
+  const binding = cs?.['binding'] as Record<string, unknown> | undefined;
+  return (
+    Array.isArray(vc.type) &&
+    vc.type.includes('BindingProofCredential') &&
+    typeof vc.issuer === 'string' &&
+    typeof vc.validFrom === 'string' &&
+    typeof vc.validUntil === 'string' &&
+    !!vc.credentialStatus &&
+    !!cs &&
+    typeof cs['id'] === 'string' &&
+    !!binding &&
+    typeof binding['from'] === 'string' &&
+    typeof binding['to'] === 'string' &&
+    typeof binding['boundAt'] === 'string'
+  );
+}
+
+/** Verify one leg's proof: assertionMethod membership + signature. */
+function verifyLegProof(
+  vc: BindingProofCredential,
+  didDoc: DidDocument,
+  publicKeyBytes: Uint8Array,
+  label: string,
+  errors: string[]
+): void {
+  if (!vc.proof) {
+    errors.push(`${label}: credential has no proof`);
+    return;
+  }
+  const vm = vc.proof.verificationMethod;
+  if (!didDoc.assertionMethod?.includes(vm)) {
+    errors.push(`${label}: proof verificationMethod (${vm}) is not in issuer assertionMethod set`);
+    return;
+  }
+  const ok = verifyProof(vc, vc.proof as DataIntegrityProof, publicKeyBytes);
+  if (!ok) {
+    errors.push(`${label}: signature verification failed`);
+  }
+}
+
+/** Check `now` falls within [validFrom, validUntil]. */
+function checkValidityWindow(
+  vc: BindingProofCredential,
+  now: string,
+  label: string,
+  errors: string[]
+): void {
+  const nowMs = Date.parse(now);
+  const fromMs = Date.parse(vc.validFrom);
+  const untilMs = Date.parse(vc.validUntil);
+  if (Number.isNaN(fromMs) || Number.isNaN(untilMs)) {
+    errors.push(`${label}: validFrom/validUntil not parseable`);
+    return;
+  }
+  if (nowMs < fromMs) {
+    errors.push(`${label}: current time is before validFrom`);
+  }
+  if (nowMs > untilMs) {
+    errors.push(`${label}: current time is after validUntil`);
+  }
 }

--- a/packages/trail-core/src/index.ts
+++ b/packages/trail-core/src/index.ts
@@ -7,7 +7,8 @@ export { createSelfDid, createOrgDid, createAgentDid, parseTrailDid, normalizeSl
 export { createDidDocument, rotateKey, SPEC_VERSION } from './document';
 export { TrailResolver, extractPublicKeyFromSelfDid } from './resolver';
 export { createProof, verifyProof, isSupportedCryptosuite, DEFAULT_CRYPTOSUITE } from './proof';
-export { createSelfSignedCredential, verifyCredential } from './credential';
+export { createSelfSignedCredential, verifyCredential, createBindingProofCredential, verifyBindingProof } from './credential';
+export type { CreateBindingProofOptions, VerifyBindingProofInput, BindingProofVerificationResult, VerificationResult } from './credential';
 export { encodeMultibase, decodeMultibase } from './base58';
 export { jcsCanonicalizeToString, jcsCanonicalizeToBuffer } from './jcs';
 
@@ -20,6 +21,9 @@ export type {
   ServiceEndpoint,
   DataIntegrityProof,
   VerifiableCredential,
+  BindingProofCredential,
+  BindingProofBinding,
+  StatusList2021Entry,
   RecoveryPolicy,
   SupportedCryptosuite,
 } from './types';

--- a/packages/trail-core/src/types.ts
+++ b/packages/trail-core/src/types.ts
@@ -30,6 +30,7 @@ export interface DidDocument {
   '@context': string[];
   id: string;
   controller?: string;
+  alsoKnownAs?: string[];
   verificationMethod: VerificationMethod[];
   authentication: string[];
   assertionMethod: string[];
@@ -87,11 +88,70 @@ export const SUPPORTED_CRYPTOSUITES: ReadonlyArray<{
   },
 ];
 
+/**
+ * StatusList2021Entry — credentialStatus entry per W3C VC Status List 2021.
+ * Used for per-credential revocation. See spec §8.7.
+ */
+export interface StatusList2021Entry {
+  id: string;
+  type: 'StatusList2021Entry';
+  statusPurpose: string;
+  statusListIndex: string;
+  statusListCredential: string;
+}
+
 export interface VerifiableCredential {
   '@context': string[];
   type: string[];
   issuer: string;
-  issuanceDate: string;
+  /**
+   * VC 1.1 issuance date. Present on TrailIdentityCredential and other
+   * VC 1.1-context credentials. Optional so VC 2.0 credentials
+   * (validFrom/validUntil) can omit it.
+   */
+  issuanceDate?: string;
+  /** VC 2.0 validity start (RFC 3339). */
+  validFrom?: string;
+  /** VC 2.0 validity end (RFC 3339). */
+  validUntil?: string;
   credentialSubject: Record<string, unknown>;
+  /** Revocation status entry (StatusList2021 per §8.7). */
+  credentialStatus?: StatusList2021Entry;
   proof?: DataIntegrityProof;
+}
+
+/**
+ * The signed `binding` object inside a BindingProofCredential's
+ * credentialSubject. See spec §5.4.5.
+ *
+ * `from` MUST equal the credential's `issuer`.
+ * `to`   MUST equal the credential's `credentialSubject.id`.
+ * `direction` is intentionally absent — reserved for a future "inbound"
+ * attestation type and fully determined by `from == issuer` for the
+ * outbound case (§5.4.5.2).
+ */
+export interface BindingProofBinding {
+  from: string;
+  to: string;
+  boundAt: string;
+}
+
+/**
+ * BindingProofCredential — one leg of a reciprocal cross-method binding.
+ * A verified binding requires two of these, one signed by each controller,
+ * each outbound from its own issuer's perspective. See spec §5.4.5.
+ *
+ * This is a structural refinement of VerifiableCredential: it fixes the
+ * VC 2.0 context/validity shape and requires credentialStatus + a
+ * credentialSubject carrying { id, binding }.
+ */
+export interface BindingProofCredential extends VerifiableCredential {
+  validFrom: string;
+  validUntil: string;
+  credentialStatus: StatusList2021Entry;
+  credentialSubject: {
+    id: string;
+    binding: BindingProofBinding;
+    [key: string]: unknown;
+  };
 }

--- a/packages/trail-core/test/roundtrip.test.ts
+++ b/packages/trail-core/test/roundtrip.test.ts
@@ -6,7 +6,9 @@ import { createDidDocument, rotateKey, SPEC_VERSION } from '../src/document';
 import { TrailResolver } from '../src/resolver';
 import { createProof, verifyProof, isSupportedCryptosuite, DEFAULT_CRYPTOSUITE } from '../src/proof';
 import { SUPPORTED_CRYPTOSUITES } from '../src/types';
-import { createSelfSignedCredential, verifyCredential } from '../src/credential';
+import { createSelfSignedCredential, verifyCredential, createBindingProofCredential, verifyBindingProof } from '../src/credential';
+import type { VerifyBindingProofInput } from '../src/credential';
+import type { DidDocument, StatusList2021Entry } from '../src/types';
 import { encode, decode, encodeMultibase, decodeMultibase } from '../src/base58';
 import { jcsCanonicalizeToString } from '../src/jcs';
 
@@ -580,5 +582,206 @@ describe('Key Rotation', () => {
     // Old key proofs still verify against old key
     const oldProof = createProof(testDoc, keys1.privateKeyBytes, `${did}#key-1`);
     assert.ok(verifyProof(testDoc, oldProof, keys1.publicKeyBytes));
+  });
+});
+
+describe('BindingProofCredential (§5.4.5)', () => {
+  // Helper: build a full valid reciprocal pair + both DID Documents + keys,
+  // so each test can mutate one thing and assert the failure.
+  function buildValidBinding() {
+    const trailKeys = generateKeyPair();
+    const foreignKeys = generateKeyPair();
+
+    // Use org DIDs for both legs (foreign leg simulated with a second trail DID
+    // is fine for the crypto — the function is method-agnostic on the foreign side).
+    const trailDid = createOrgDid('Binding Trail Co', trailKeys.publicKeyMultibase);
+    const foreignDid = createOrgDid('Binding Foreign Co', foreignKeys.publicKeyMultibase);
+
+    const trailStatus: StatusList2021Entry = {
+      id: 'https://registry.trailprotocol.org/1.0/status/2026-06#42',
+      type: 'StatusList2021Entry',
+      statusPurpose: 'revocation',
+      statusListIndex: '42',
+      statusListCredential: 'https://registry.trailprotocol.org/1.0/status/2026-06',
+    };
+    const foreignStatus: StatusList2021Entry = {
+      id: 'https://foreign.example/status/2026-06#7',
+      type: 'StatusList2021Entry',
+      statusPurpose: 'revocation',
+      statusListIndex: '7',
+      statusListCredential: 'https://foreign.example/status/2026-06',
+    };
+
+    const validFrom = '2026-06-15T00:00:00Z';
+    const validUntil = '2027-06-15T00:00:00Z';
+
+    const trailCredential = createBindingProofCredential({
+      issuerDid: trailDid,
+      subjectDid: foreignDid,
+      privateKeyBytes: trailKeys.privateKeyBytes,
+      credentialStatus: trailStatus,
+      validFrom,
+      validUntil,
+    });
+    const foreignCredential = createBindingProofCredential({
+      issuerDid: foreignDid,
+      subjectDid: trailDid,
+      privateKeyBytes: foreignKeys.privateKeyBytes,
+      credentialStatus: foreignStatus,
+      validFrom,
+      validUntil,
+    });
+
+    // DID Documents WITH reciprocal alsoKnownAs (step 1 precondition).
+    const trailDidDocument: DidDocument = {
+      ...createDidDocument(trailDid, trailKeys, { mode: 'org' }),
+      alsoKnownAs: [foreignDid],
+    };
+    const foreignDidDocument: DidDocument = {
+      ...createDidDocument(foreignDid, foreignKeys, { mode: 'org' }),
+      alsoKnownAs: [trailDid],
+    };
+
+    const input: VerifyBindingProofInput = {
+      trailCredential,
+      foreignCredential,
+      trailDidDocument,
+      foreignDidDocument,
+      trailPublicKeyBytes: trailKeys.publicKeyBytes,
+      foreignPublicKeyBytes: foreignKeys.publicKeyBytes,
+      revocation: { trailCredentialRevoked: false, foreignCredentialRevoked: false },
+      now: '2026-09-01T00:00:00Z',
+    };
+
+    return { input, trailKeys, foreignKeys, trailDid, foreignDid };
+  }
+
+  it('createBindingProofCredential produces a correctly-shaped outbound leg', () => {
+    const { input, trailDid, foreignDid } = buildValidBinding();
+    const c = input.trailCredential;
+    assert.deepStrictEqual(c['@context'], [
+      'https://www.w3.org/ns/credentials/v2',
+      'https://trailprotocol.org/ns/credentials/v2',
+    ]);
+    assert.deepStrictEqual(c.type, ['VerifiableCredential', 'BindingProofCredential']);
+    assert.strictEqual(c.issuer, trailDid);
+    assert.strictEqual(c.credentialSubject.id, foreignDid);
+    assert.strictEqual(c.credentialSubject.binding.from, trailDid);
+    assert.strictEqual(c.credentialSubject.binding.to, foreignDid);
+    // direction MUST NOT be present
+    assert.strictEqual(
+      Object.prototype.hasOwnProperty.call(c.credentialSubject.binding, 'direction'),
+      false
+    );
+    assert.ok(c.proof, 'leg must carry a proof');
+  });
+
+  it('boundAt defaults to validFrom when omitted', () => {
+    const { input } = buildValidBinding();
+    assert.strictEqual(
+      input.trailCredential.credentialSubject.binding.boundAt,
+      input.trailCredential.validFrom
+    );
+  });
+
+  it('verifies a complete valid reciprocal pair', () => {
+    const { input } = buildValidBinding();
+    const result = verifyBindingProof(input);
+    assert.deepStrictEqual(result.errors, []);
+    assert.strictEqual(result.verified, true);
+  });
+
+  it('fails when the trail leg has a tampered signature (step 4)', () => {
+    const { input } = buildValidBinding();
+    // Mutate credentialSubject after signing → JCS digest no longer matches proof.
+    input.trailCredential.credentialSubject.binding.boundAt = '2099-01-01T00:00:00Z';
+    const result = verifyBindingProof(input);
+    assert.strictEqual(result.verified, false);
+    assert.ok(result.errors.some(e => e.includes('Step 4')));
+  });
+
+  it('fails when the reciprocal back-reference is missing (step 1)', () => {
+    const { input } = buildValidBinding();
+    input.foreignDidDocument.alsoKnownAs = []; // drop the back-reference
+    const result = verifyBindingProof(input);
+    assert.strictEqual(result.verified, false);
+    assert.ok(result.errors.some(e => e.includes('Step 1')));
+  });
+
+  it('fails when a credential is expired (step 6)', () => {
+    const { input } = buildValidBinding();
+    input.now = '2030-01-01T00:00:00Z'; // past validUntil
+    const result = verifyBindingProof(input);
+    assert.strictEqual(result.verified, false);
+    assert.ok(result.errors.some(e => e.includes('Step 6')));
+  });
+
+  it('fails when a credential is revoked via credentialStatus (step 7)', () => {
+    const { input } = buildValidBinding();
+    input.revocation.foreignCredentialRevoked = true;
+    const result = verifyBindingProof(input);
+    assert.strictEqual(result.verified, false);
+    assert.ok(result.errors.some(e => e.includes('Step 7')));
+  });
+
+  it('fails when the signing key is revoked at verification time (step 5)', () => {
+    const { input } = buildValidBinding();
+    input.keyRevocation = { trailSigningKeyRevoked: true, foreignSigningKeyRevoked: false };
+    const result = verifyBindingProof(input);
+    assert.strictEqual(result.verified, false);
+    assert.ok(result.errors.some(e => e.includes('Step 5')));
+  });
+
+  it('fails when binding.to does not match the counterpart DID (step 2)', () => {
+    const { input } = buildValidBinding();
+    // Re-point the trail leg's binding.to at a bogus DID (breaks orientation).
+    input.trailCredential.credentialSubject.binding.to = 'did:trail:org:not-the-foreign-did-0000000000000000';
+    input.trailCredential.credentialSubject.id = 'did:trail:org:not-the-foreign-did-0000000000000000';
+    const result = verifyBindingProof(input);
+    assert.strictEqual(result.verified, false);
+    assert.ok(result.errors.some(e => e.includes('Step 2')));
+  });
+
+  it('a single-party pair still verifies (documents the consent≠identity limitation, §5.4.5.4)', () => {
+    // One key controls both legs: valid pair, but proves consent not distinctness.
+    const soleKeys = generateKeyPair();
+    const didA = createOrgDid('Sole Controller A', soleKeys.publicKeyMultibase);
+    // Second DID from a different slug but SAME key material — a single party.
+    const didB = createOrgDid('Sole Controller B', soleKeys.publicKeyMultibase);
+
+    const status = (idx: string): StatusList2021Entry => ({
+      id: `https://registry.trailprotocol.org/1.0/status/2026-06#${idx}`,
+      type: 'StatusList2021Entry',
+      statusPurpose: 'revocation',
+      statusListIndex: idx,
+      statusListCredential: 'https://registry.trailprotocol.org/1.0/status/2026-06',
+    });
+
+    const validFrom = '2026-06-15T00:00:00Z';
+    const validUntil = '2027-06-15T00:00:00Z';
+
+    const legA = createBindingProofCredential({
+      issuerDid: didA, subjectDid: didB, privateKeyBytes: soleKeys.privateKeyBytes,
+      credentialStatus: status('1'), validFrom, validUntil,
+    });
+    const legB = createBindingProofCredential({
+      issuerDid: didB, subjectDid: didA, privateKeyBytes: soleKeys.privateKeyBytes,
+      credentialStatus: status('2'), validFrom, validUntil,
+    });
+
+    const docA: DidDocument = { ...createDidDocument(didA, soleKeys, { mode: 'org' }), alsoKnownAs: [didB] };
+    const docB: DidDocument = { ...createDidDocument(didB, soleKeys, { mode: 'org' }), alsoKnownAs: [didA] };
+
+    const result = verifyBindingProof({
+      trailCredential: legA, foreignCredential: legB,
+      trailDidDocument: docA, foreignDidDocument: docB,
+      trailPublicKeyBytes: soleKeys.publicKeyBytes,
+      foreignPublicKeyBytes: soleKeys.publicKeyBytes,
+      revocation: { trailCredentialRevoked: false, foreignCredentialRevoked: false },
+      now: '2026-09-01T00:00:00Z',
+    });
+
+    // Cryptographically verified — this is exactly the §5.4.5.4 limitation.
+    assert.strictEqual(result.verified, true);
   });
 });

--- a/validation/fixtures/invalid-binding-proof-bad-signature.json
+++ b/validation/fixtures/invalid-binding-proof-bad-signature.json
@@ -1,0 +1,157 @@
+{
+  "_comment": "Test vectors for BindingProofCredential (§5.4.5). Public keys are base64(raw 32-byte Ed25519) so verifiers can check the signatures. Private keys intentionally omitted.",
+  "trailPublicKeyBase64": "TInNUpvZBwVJL2DJ9On2nUd1Ntrb1lN9tHQHdAKcnBo=",
+  "foreignPublicKeyBase64": "DDEI6DMMWDfHs9x4ACNGe9TY9kZbRL/yAwq7d/PLYbo=",
+  "trailDidDocument": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://trailprotocol.org/ns/did/v1"
+    ],
+    "id": "did:trail:org:acme-corp-eu-94b549601e80458e",
+    "verificationMethod": [
+      {
+        "id": "did:trail:org:acme-corp-eu-94b549601e80458e#key-1",
+        "type": "JsonWebKey2020",
+        "controller": "did:trail:org:acme-corp-eu-94b549601e80458e",
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "TInNUpvZBwVJL2DJ9On2nUd1Ntrb1lN9tHQHdAKcnBo"
+        }
+      }
+    ],
+    "authentication": [
+      "did:trail:org:acme-corp-eu-94b549601e80458e#key-1"
+    ],
+    "assertionMethod": [
+      "did:trail:org:acme-corp-eu-94b549601e80458e#key-1"
+    ],
+    "trail:trailMode": "org",
+    "trail:supportedCryptosuites": [
+      "eddsa-jcs-2023"
+    ],
+    "trail:specVersion": "1.1.0",
+    "service": [
+      {
+        "id": "did:trail:org:acme-corp-eu-94b549601e80458e#trail-registry",
+        "type": "TrailRegistryService",
+        "serviceEndpoint": "https://registry.trailprotocol.org/1.0/identifiers/did:trail:org:acme-corp-eu-94b549601e80458e"
+      }
+    ],
+    "alsoKnownAs": [
+      "did:trail:org:acme-web-agent-1b2641281557b5c4"
+    ]
+  },
+  "foreignDidDocument": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://trailprotocol.org/ns/did/v1"
+    ],
+    "id": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+    "verificationMethod": [
+      {
+        "id": "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1",
+        "type": "JsonWebKey2020",
+        "controller": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "DDEI6DMMWDfHs9x4ACNGe9TY9kZbRL_yAwq7d_PLYbo"
+        }
+      }
+    ],
+    "authentication": [
+      "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1"
+    ],
+    "assertionMethod": [
+      "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1"
+    ],
+    "trail:trailMode": "org",
+    "trail:supportedCryptosuites": [
+      "eddsa-jcs-2023"
+    ],
+    "trail:specVersion": "1.1.0",
+    "service": [
+      {
+        "id": "did:trail:org:acme-web-agent-1b2641281557b5c4#trail-registry",
+        "type": "TrailRegistryService",
+        "serviceEndpoint": "https://registry.trailprotocol.org/1.0/identifiers/did:trail:org:acme-web-agent-1b2641281557b5c4"
+      }
+    ],
+    "alsoKnownAs": [
+      "did:trail:org:acme-corp-eu-94b549601e80458e"
+    ]
+  },
+  "trailCredential": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://trailprotocol.org/ns/credentials/v2"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "BindingProofCredential"
+    ],
+    "issuer": "did:trail:org:acme-corp-eu-94b549601e80458e",
+    "validFrom": "2026-06-15T00:00:00Z",
+    "validUntil": "2027-06-15T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+      "binding": {
+        "from": "did:trail:org:acme-corp-eu-94b549601e80458e",
+        "to": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+        "boundAt": "2026-06-15T00:00:00Z"
+      }
+    },
+    "credentialStatus": {
+      "id": "https://registry.trailprotocol.org/1.0/status/2026-06#42",
+      "type": "StatusList2021Entry",
+      "statusPurpose": "revocation",
+      "statusListIndex": "42",
+      "statusListCredential": "https://registry.trailprotocol.org/1.0/status/2026-06"
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2023",
+      "created": "2026-07-01T05:12:08.263Z",
+      "verificationMethod": "did:trail:org:acme-corp-eu-94b549601e80458e#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z4bDpw98vxFdrLc9WteaeHEeKckyZ3Kkvbapi7C585Ypm439WJwYnFLa3LzCNJzeSb1CBkTiUYwJPB61iN4ntAAAA"
+    }
+  },
+  "foreignCredential": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://trailprotocol.org/ns/credentials/v2"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "BindingProofCredential"
+    ],
+    "issuer": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+    "validFrom": "2026-06-15T00:00:00Z",
+    "validUntil": "2027-06-15T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:trail:org:acme-corp-eu-94b549601e80458e",
+      "binding": {
+        "from": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+        "to": "did:trail:org:acme-corp-eu-94b549601e80458e",
+        "boundAt": "2026-06-15T00:00:00Z"
+      }
+    },
+    "credentialStatus": {
+      "id": "https://acme-corp.eu/credentials/status/2026-06#7",
+      "type": "StatusList2021Entry",
+      "statusPurpose": "revocation",
+      "statusListIndex": "7",
+      "statusListCredential": "https://acme-corp.eu/credentials/status/2026-06"
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2023",
+      "created": "2026-07-01T05:12:08.264Z",
+      "verificationMethod": "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z2e77TZyH2KWKrTuPEZrcVPHdCucRz2DeNSW1MZ5ZnuWSR99iUiVHMA7swSRgucjRou3teqZ3CeWBTaeLf4bLj1Kr"
+    }
+  }
+}

--- a/validation/fixtures/invalid-binding-proof-credential-revoked.json
+++ b/validation/fixtures/invalid-binding-proof-credential-revoked.json
@@ -1,0 +1,161 @@
+{
+  "_comment": "Test vectors for BindingProofCredential (§5.4.5). Public keys are base64(raw 32-byte Ed25519) so verifiers can check the signatures. Private keys intentionally omitted.",
+  "trailPublicKeyBase64": "TInNUpvZBwVJL2DJ9On2nUd1Ntrb1lN9tHQHdAKcnBo=",
+  "foreignPublicKeyBase64": "DDEI6DMMWDfHs9x4ACNGe9TY9kZbRL/yAwq7d/PLYbo=",
+  "callerRevocationInput": {
+    "trailCredentialRevoked": false,
+    "foreignCredentialRevoked": true
+  },
+  "trailDidDocument": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://trailprotocol.org/ns/did/v1"
+    ],
+    "id": "did:trail:org:acme-corp-eu-94b549601e80458e",
+    "verificationMethod": [
+      {
+        "id": "did:trail:org:acme-corp-eu-94b549601e80458e#key-1",
+        "type": "JsonWebKey2020",
+        "controller": "did:trail:org:acme-corp-eu-94b549601e80458e",
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "TInNUpvZBwVJL2DJ9On2nUd1Ntrb1lN9tHQHdAKcnBo"
+        }
+      }
+    ],
+    "authentication": [
+      "did:trail:org:acme-corp-eu-94b549601e80458e#key-1"
+    ],
+    "assertionMethod": [
+      "did:trail:org:acme-corp-eu-94b549601e80458e#key-1"
+    ],
+    "trail:trailMode": "org",
+    "trail:supportedCryptosuites": [
+      "eddsa-jcs-2023"
+    ],
+    "trail:specVersion": "1.1.0",
+    "service": [
+      {
+        "id": "did:trail:org:acme-corp-eu-94b549601e80458e#trail-registry",
+        "type": "TrailRegistryService",
+        "serviceEndpoint": "https://registry.trailprotocol.org/1.0/identifiers/did:trail:org:acme-corp-eu-94b549601e80458e"
+      }
+    ],
+    "alsoKnownAs": [
+      "did:trail:org:acme-web-agent-1b2641281557b5c4"
+    ]
+  },
+  "foreignDidDocument": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://trailprotocol.org/ns/did/v1"
+    ],
+    "id": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+    "verificationMethod": [
+      {
+        "id": "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1",
+        "type": "JsonWebKey2020",
+        "controller": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "DDEI6DMMWDfHs9x4ACNGe9TY9kZbRL_yAwq7d_PLYbo"
+        }
+      }
+    ],
+    "authentication": [
+      "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1"
+    ],
+    "assertionMethod": [
+      "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1"
+    ],
+    "trail:trailMode": "org",
+    "trail:supportedCryptosuites": [
+      "eddsa-jcs-2023"
+    ],
+    "trail:specVersion": "1.1.0",
+    "service": [
+      {
+        "id": "did:trail:org:acme-web-agent-1b2641281557b5c4#trail-registry",
+        "type": "TrailRegistryService",
+        "serviceEndpoint": "https://registry.trailprotocol.org/1.0/identifiers/did:trail:org:acme-web-agent-1b2641281557b5c4"
+      }
+    ],
+    "alsoKnownAs": [
+      "did:trail:org:acme-corp-eu-94b549601e80458e"
+    ]
+  },
+  "trailCredential": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://trailprotocol.org/ns/credentials/v2"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "BindingProofCredential"
+    ],
+    "issuer": "did:trail:org:acme-corp-eu-94b549601e80458e",
+    "validFrom": "2026-06-15T00:00:00Z",
+    "validUntil": "2027-06-15T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+      "binding": {
+        "from": "did:trail:org:acme-corp-eu-94b549601e80458e",
+        "to": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+        "boundAt": "2026-06-15T00:00:00Z"
+      }
+    },
+    "credentialStatus": {
+      "id": "https://registry.trailprotocol.org/1.0/status/2026-06#42",
+      "type": "StatusList2021Entry",
+      "statusPurpose": "revocation",
+      "statusListIndex": "42",
+      "statusListCredential": "https://registry.trailprotocol.org/1.0/status/2026-06"
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2023",
+      "created": "2026-07-01T05:12:08.263Z",
+      "verificationMethod": "did:trail:org:acme-corp-eu-94b549601e80458e#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z4bDpw98vxFdrLc9WteaeHEeKckyZ3Kkvbapi7C585Ypm439WJwYnFLa3LzCNJzeSb1CBkTiUYwJPB61iN4nt7fUG"
+    }
+  },
+  "foreignCredential": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://trailprotocol.org/ns/credentials/v2"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "BindingProofCredential"
+    ],
+    "issuer": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+    "validFrom": "2026-06-15T00:00:00Z",
+    "validUntil": "2027-06-15T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:trail:org:acme-corp-eu-94b549601e80458e",
+      "binding": {
+        "from": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+        "to": "did:trail:org:acme-corp-eu-94b549601e80458e",
+        "boundAt": "2026-06-15T00:00:00Z"
+      }
+    },
+    "credentialStatus": {
+      "id": "https://acme-corp.eu/credentials/status/2026-06#7",
+      "type": "StatusList2021Entry",
+      "statusPurpose": "revocation",
+      "statusListIndex": "7",
+      "statusListCredential": "https://acme-corp.eu/credentials/status/2026-06"
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2023",
+      "created": "2026-07-01T05:12:08.264Z",
+      "verificationMethod": "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z2e77TZyH2KWKrTuPEZrcVPHdCucRz2DeNSW1MZ5ZnuWSR99iUiVHMA7swSRgucjRou3teqZ3CeWBTaeLf4bLj1Kr"
+    }
+  }
+}

--- a/validation/fixtures/invalid-binding-proof-expired.json
+++ b/validation/fixtures/invalid-binding-proof-expired.json
@@ -1,0 +1,158 @@
+{
+  "_comment": "Trail leg validUntil (2026-06-16) is before the verificationTime (2026-09-01). Signature is VALID (window baked in before signing) — fails ONLY §5.4.5.3 step 6.",
+  "trailPublicKeyBase64": "CPzeiXgxtqFas7yzpE33m639hEBvQJn3WTh/C/VgAGY=",
+  "foreignPublicKeyBase64": "I0VvrjTfwzzncAM6IJOcyKfCrLQXxvwPaTQpVhWsyt4=",
+  "verificationTime": "2026-09-01T00:00:00Z",
+  "trailDidDocument": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://trailprotocol.org/ns/did/v1"
+    ],
+    "id": "did:trail:org:acme-corp-eu-570cb6cc823ad59e",
+    "verificationMethod": [
+      {
+        "id": "did:trail:org:acme-corp-eu-570cb6cc823ad59e#key-1",
+        "type": "JsonWebKey2020",
+        "controller": "did:trail:org:acme-corp-eu-570cb6cc823ad59e",
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "CPzeiXgxtqFas7yzpE33m639hEBvQJn3WTh_C_VgAGY"
+        }
+      }
+    ],
+    "authentication": [
+      "did:trail:org:acme-corp-eu-570cb6cc823ad59e#key-1"
+    ],
+    "assertionMethod": [
+      "did:trail:org:acme-corp-eu-570cb6cc823ad59e#key-1"
+    ],
+    "trail:trailMode": "org",
+    "trail:supportedCryptosuites": [
+      "eddsa-jcs-2023"
+    ],
+    "trail:specVersion": "1.1.0",
+    "service": [
+      {
+        "id": "did:trail:org:acme-corp-eu-570cb6cc823ad59e#trail-registry",
+        "type": "TrailRegistryService",
+        "serviceEndpoint": "https://registry.trailprotocol.org/1.0/identifiers/did:trail:org:acme-corp-eu-570cb6cc823ad59e"
+      }
+    ],
+    "alsoKnownAs": [
+      "did:trail:org:acme-web-agent-0eb4f15ccf199e0f"
+    ]
+  },
+  "foreignDidDocument": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://trailprotocol.org/ns/did/v1"
+    ],
+    "id": "did:trail:org:acme-web-agent-0eb4f15ccf199e0f",
+    "verificationMethod": [
+      {
+        "id": "did:trail:org:acme-web-agent-0eb4f15ccf199e0f#key-1",
+        "type": "JsonWebKey2020",
+        "controller": "did:trail:org:acme-web-agent-0eb4f15ccf199e0f",
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "I0VvrjTfwzzncAM6IJOcyKfCrLQXxvwPaTQpVhWsyt4"
+        }
+      }
+    ],
+    "authentication": [
+      "did:trail:org:acme-web-agent-0eb4f15ccf199e0f#key-1"
+    ],
+    "assertionMethod": [
+      "did:trail:org:acme-web-agent-0eb4f15ccf199e0f#key-1"
+    ],
+    "trail:trailMode": "org",
+    "trail:supportedCryptosuites": [
+      "eddsa-jcs-2023"
+    ],
+    "trail:specVersion": "1.1.0",
+    "service": [
+      {
+        "id": "did:trail:org:acme-web-agent-0eb4f15ccf199e0f#trail-registry",
+        "type": "TrailRegistryService",
+        "serviceEndpoint": "https://registry.trailprotocol.org/1.0/identifiers/did:trail:org:acme-web-agent-0eb4f15ccf199e0f"
+      }
+    ],
+    "alsoKnownAs": [
+      "did:trail:org:acme-corp-eu-570cb6cc823ad59e"
+    ]
+  },
+  "trailCredential": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://trailprotocol.org/ns/credentials/v2"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "BindingProofCredential"
+    ],
+    "issuer": "did:trail:org:acme-corp-eu-570cb6cc823ad59e",
+    "validFrom": "2026-06-15T00:00:00Z",
+    "validUntil": "2026-06-16T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:trail:org:acme-web-agent-0eb4f15ccf199e0f",
+      "binding": {
+        "from": "did:trail:org:acme-corp-eu-570cb6cc823ad59e",
+        "to": "did:trail:org:acme-web-agent-0eb4f15ccf199e0f",
+        "boundAt": "2026-06-15T00:00:00Z"
+      }
+    },
+    "credentialStatus": {
+      "id": "https://registry.trailprotocol.org/1.0/status/2026-06#42",
+      "type": "StatusList2021Entry",
+      "statusPurpose": "revocation",
+      "statusListIndex": "42",
+      "statusListCredential": "https://registry.trailprotocol.org/1.0/status/2026-06"
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2023",
+      "created": "2026-07-01T20:39:53.306Z",
+      "verificationMethod": "did:trail:org:acme-corp-eu-570cb6cc823ad59e#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "zkLZRezzPhiipwzJvwVQyGG2LuWKoLFa5KuUWMCXM7VU8HFASP7SR5NBbBHFjviT9CakCWivqYoVgpfycNnv7jzU"
+    }
+  },
+  "foreignCredential": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://trailprotocol.org/ns/credentials/v2"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "BindingProofCredential"
+    ],
+    "issuer": "did:trail:org:acme-web-agent-0eb4f15ccf199e0f",
+    "validFrom": "2026-06-15T00:00:00Z",
+    "validUntil": "2027-06-15T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:trail:org:acme-corp-eu-570cb6cc823ad59e",
+      "binding": {
+        "from": "did:trail:org:acme-web-agent-0eb4f15ccf199e0f",
+        "to": "did:trail:org:acme-corp-eu-570cb6cc823ad59e",
+        "boundAt": "2026-06-15T00:00:00Z"
+      }
+    },
+    "credentialStatus": {
+      "id": "https://acme-corp.eu/credentials/status/2026-06#7",
+      "type": "StatusList2021Entry",
+      "statusPurpose": "revocation",
+      "statusListIndex": "7",
+      "statusListCredential": "https://acme-corp.eu/credentials/status/2026-06"
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2023",
+      "created": "2026-07-01T20:39:53.307Z",
+      "verificationMethod": "did:trail:org:acme-web-agent-0eb4f15ccf199e0f#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z5xNLhoakgW2CRvzr85UL4rdHc2cnyosZZgLozAvJ43neBE6orNoX8tgZnb6t54tyz2Wdz3zNiHP5CqYtu3JSDtFe"
+    }
+  }
+}

--- a/validation/fixtures/invalid-binding-proof-missing-reciprocal.json
+++ b/validation/fixtures/invalid-binding-proof-missing-reciprocal.json
@@ -1,0 +1,155 @@
+{
+  "_comment": "Test vectors for BindingProofCredential (§5.4.5). Public keys are base64(raw 32-byte Ed25519) so verifiers can check the signatures. Private keys intentionally omitted.",
+  "trailPublicKeyBase64": "TInNUpvZBwVJL2DJ9On2nUd1Ntrb1lN9tHQHdAKcnBo=",
+  "foreignPublicKeyBase64": "DDEI6DMMWDfHs9x4ACNGe9TY9kZbRL/yAwq7d/PLYbo=",
+  "trailDidDocument": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://trailprotocol.org/ns/did/v1"
+    ],
+    "id": "did:trail:org:acme-corp-eu-94b549601e80458e",
+    "verificationMethod": [
+      {
+        "id": "did:trail:org:acme-corp-eu-94b549601e80458e#key-1",
+        "type": "JsonWebKey2020",
+        "controller": "did:trail:org:acme-corp-eu-94b549601e80458e",
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "TInNUpvZBwVJL2DJ9On2nUd1Ntrb1lN9tHQHdAKcnBo"
+        }
+      }
+    ],
+    "authentication": [
+      "did:trail:org:acme-corp-eu-94b549601e80458e#key-1"
+    ],
+    "assertionMethod": [
+      "did:trail:org:acme-corp-eu-94b549601e80458e#key-1"
+    ],
+    "trail:trailMode": "org",
+    "trail:supportedCryptosuites": [
+      "eddsa-jcs-2023"
+    ],
+    "trail:specVersion": "1.1.0",
+    "service": [
+      {
+        "id": "did:trail:org:acme-corp-eu-94b549601e80458e#trail-registry",
+        "type": "TrailRegistryService",
+        "serviceEndpoint": "https://registry.trailprotocol.org/1.0/identifiers/did:trail:org:acme-corp-eu-94b549601e80458e"
+      }
+    ],
+    "alsoKnownAs": [
+      "did:trail:org:acme-web-agent-1b2641281557b5c4"
+    ]
+  },
+  "foreignDidDocument": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://trailprotocol.org/ns/did/v1"
+    ],
+    "id": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+    "verificationMethod": [
+      {
+        "id": "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1",
+        "type": "JsonWebKey2020",
+        "controller": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "DDEI6DMMWDfHs9x4ACNGe9TY9kZbRL_yAwq7d_PLYbo"
+        }
+      }
+    ],
+    "authentication": [
+      "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1"
+    ],
+    "assertionMethod": [
+      "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1"
+    ],
+    "trail:trailMode": "org",
+    "trail:supportedCryptosuites": [
+      "eddsa-jcs-2023"
+    ],
+    "trail:specVersion": "1.1.0",
+    "service": [
+      {
+        "id": "did:trail:org:acme-web-agent-1b2641281557b5c4#trail-registry",
+        "type": "TrailRegistryService",
+        "serviceEndpoint": "https://registry.trailprotocol.org/1.0/identifiers/did:trail:org:acme-web-agent-1b2641281557b5c4"
+      }
+    ],
+    "alsoKnownAs": []
+  },
+  "trailCredential": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://trailprotocol.org/ns/credentials/v2"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "BindingProofCredential"
+    ],
+    "issuer": "did:trail:org:acme-corp-eu-94b549601e80458e",
+    "validFrom": "2026-06-15T00:00:00Z",
+    "validUntil": "2027-06-15T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+      "binding": {
+        "from": "did:trail:org:acme-corp-eu-94b549601e80458e",
+        "to": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+        "boundAt": "2026-06-15T00:00:00Z"
+      }
+    },
+    "credentialStatus": {
+      "id": "https://registry.trailprotocol.org/1.0/status/2026-06#42",
+      "type": "StatusList2021Entry",
+      "statusPurpose": "revocation",
+      "statusListIndex": "42",
+      "statusListCredential": "https://registry.trailprotocol.org/1.0/status/2026-06"
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2023",
+      "created": "2026-07-01T05:12:08.263Z",
+      "verificationMethod": "did:trail:org:acme-corp-eu-94b549601e80458e#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z4bDpw98vxFdrLc9WteaeHEeKckyZ3Kkvbapi7C585Ypm439WJwYnFLa3LzCNJzeSb1CBkTiUYwJPB61iN4nt7fUG"
+    }
+  },
+  "foreignCredential": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://trailprotocol.org/ns/credentials/v2"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "BindingProofCredential"
+    ],
+    "issuer": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+    "validFrom": "2026-06-15T00:00:00Z",
+    "validUntil": "2027-06-15T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:trail:org:acme-corp-eu-94b549601e80458e",
+      "binding": {
+        "from": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+        "to": "did:trail:org:acme-corp-eu-94b549601e80458e",
+        "boundAt": "2026-06-15T00:00:00Z"
+      }
+    },
+    "credentialStatus": {
+      "id": "https://acme-corp.eu/credentials/status/2026-06#7",
+      "type": "StatusList2021Entry",
+      "statusPurpose": "revocation",
+      "statusListIndex": "7",
+      "statusListCredential": "https://acme-corp.eu/credentials/status/2026-06"
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2023",
+      "created": "2026-07-01T05:12:08.264Z",
+      "verificationMethod": "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z2e77TZyH2KWKrTuPEZrcVPHdCucRz2DeNSW1MZ5ZnuWSR99iUiVHMA7swSRgucjRou3teqZ3CeWBTaeLf4bLj1Kr"
+    }
+  }
+}

--- a/validation/fixtures/invalid-binding-proof-signing-key-revoked.json
+++ b/validation/fixtures/invalid-binding-proof-signing-key-revoked.json
@@ -1,0 +1,161 @@
+{
+  "_comment": "Test vectors for BindingProofCredential (§5.4.5). Public keys are base64(raw 32-byte Ed25519) so verifiers can check the signatures. Private keys intentionally omitted.",
+  "trailPublicKeyBase64": "TInNUpvZBwVJL2DJ9On2nUd1Ntrb1lN9tHQHdAKcnBo=",
+  "foreignPublicKeyBase64": "DDEI6DMMWDfHs9x4ACNGe9TY9kZbRL/yAwq7d/PLYbo=",
+  "callerKeyRevocationInput": {
+    "trailSigningKeyRevoked": true,
+    "foreignSigningKeyRevoked": false
+  },
+  "trailDidDocument": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://trailprotocol.org/ns/did/v1"
+    ],
+    "id": "did:trail:org:acme-corp-eu-94b549601e80458e",
+    "verificationMethod": [
+      {
+        "id": "did:trail:org:acme-corp-eu-94b549601e80458e#key-1",
+        "type": "JsonWebKey2020",
+        "controller": "did:trail:org:acme-corp-eu-94b549601e80458e",
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "TInNUpvZBwVJL2DJ9On2nUd1Ntrb1lN9tHQHdAKcnBo"
+        }
+      }
+    ],
+    "authentication": [
+      "did:trail:org:acme-corp-eu-94b549601e80458e#key-1"
+    ],
+    "assertionMethod": [
+      "did:trail:org:acme-corp-eu-94b549601e80458e#key-1"
+    ],
+    "trail:trailMode": "org",
+    "trail:supportedCryptosuites": [
+      "eddsa-jcs-2023"
+    ],
+    "trail:specVersion": "1.1.0",
+    "service": [
+      {
+        "id": "did:trail:org:acme-corp-eu-94b549601e80458e#trail-registry",
+        "type": "TrailRegistryService",
+        "serviceEndpoint": "https://registry.trailprotocol.org/1.0/identifiers/did:trail:org:acme-corp-eu-94b549601e80458e"
+      }
+    ],
+    "alsoKnownAs": [
+      "did:trail:org:acme-web-agent-1b2641281557b5c4"
+    ]
+  },
+  "foreignDidDocument": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://trailprotocol.org/ns/did/v1"
+    ],
+    "id": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+    "verificationMethod": [
+      {
+        "id": "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1",
+        "type": "JsonWebKey2020",
+        "controller": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "DDEI6DMMWDfHs9x4ACNGe9TY9kZbRL_yAwq7d_PLYbo"
+        }
+      }
+    ],
+    "authentication": [
+      "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1"
+    ],
+    "assertionMethod": [
+      "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1"
+    ],
+    "trail:trailMode": "org",
+    "trail:supportedCryptosuites": [
+      "eddsa-jcs-2023"
+    ],
+    "trail:specVersion": "1.1.0",
+    "service": [
+      {
+        "id": "did:trail:org:acme-web-agent-1b2641281557b5c4#trail-registry",
+        "type": "TrailRegistryService",
+        "serviceEndpoint": "https://registry.trailprotocol.org/1.0/identifiers/did:trail:org:acme-web-agent-1b2641281557b5c4"
+      }
+    ],
+    "alsoKnownAs": [
+      "did:trail:org:acme-corp-eu-94b549601e80458e"
+    ]
+  },
+  "trailCredential": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://trailprotocol.org/ns/credentials/v2"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "BindingProofCredential"
+    ],
+    "issuer": "did:trail:org:acme-corp-eu-94b549601e80458e",
+    "validFrom": "2026-06-15T00:00:00Z",
+    "validUntil": "2027-06-15T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+      "binding": {
+        "from": "did:trail:org:acme-corp-eu-94b549601e80458e",
+        "to": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+        "boundAt": "2026-06-15T00:00:00Z"
+      }
+    },
+    "credentialStatus": {
+      "id": "https://registry.trailprotocol.org/1.0/status/2026-06#42",
+      "type": "StatusList2021Entry",
+      "statusPurpose": "revocation",
+      "statusListIndex": "42",
+      "statusListCredential": "https://registry.trailprotocol.org/1.0/status/2026-06"
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2023",
+      "created": "2026-07-01T05:12:08.263Z",
+      "verificationMethod": "did:trail:org:acme-corp-eu-94b549601e80458e#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z4bDpw98vxFdrLc9WteaeHEeKckyZ3Kkvbapi7C585Ypm439WJwYnFLa3LzCNJzeSb1CBkTiUYwJPB61iN4nt7fUG"
+    }
+  },
+  "foreignCredential": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://trailprotocol.org/ns/credentials/v2"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "BindingProofCredential"
+    ],
+    "issuer": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+    "validFrom": "2026-06-15T00:00:00Z",
+    "validUntil": "2027-06-15T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:trail:org:acme-corp-eu-94b549601e80458e",
+      "binding": {
+        "from": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+        "to": "did:trail:org:acme-corp-eu-94b549601e80458e",
+        "boundAt": "2026-06-15T00:00:00Z"
+      }
+    },
+    "credentialStatus": {
+      "id": "https://acme-corp.eu/credentials/status/2026-06#7",
+      "type": "StatusList2021Entry",
+      "statusPurpose": "revocation",
+      "statusListIndex": "7",
+      "statusListCredential": "https://acme-corp.eu/credentials/status/2026-06"
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2023",
+      "created": "2026-07-01T05:12:08.264Z",
+      "verificationMethod": "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z2e77TZyH2KWKrTuPEZrcVPHdCucRz2DeNSW1MZ5ZnuWSR99iUiVHMA7swSRgucjRou3teqZ3CeWBTaeLf4bLj1Kr"
+    }
+  }
+}

--- a/validation/fixtures/valid-binding-proof-pair.json
+++ b/validation/fixtures/valid-binding-proof-pair.json
@@ -1,0 +1,157 @@
+{
+  "_comment": "Test vectors for BindingProofCredential (§5.4.5). Public keys are base64(raw 32-byte Ed25519) so verifiers can check the signatures. Private keys intentionally omitted.",
+  "trailPublicKeyBase64": "TInNUpvZBwVJL2DJ9On2nUd1Ntrb1lN9tHQHdAKcnBo=",
+  "foreignPublicKeyBase64": "DDEI6DMMWDfHs9x4ACNGe9TY9kZbRL/yAwq7d/PLYbo=",
+  "trailDidDocument": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://trailprotocol.org/ns/did/v1"
+    ],
+    "id": "did:trail:org:acme-corp-eu-94b549601e80458e",
+    "verificationMethod": [
+      {
+        "id": "did:trail:org:acme-corp-eu-94b549601e80458e#key-1",
+        "type": "JsonWebKey2020",
+        "controller": "did:trail:org:acme-corp-eu-94b549601e80458e",
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "TInNUpvZBwVJL2DJ9On2nUd1Ntrb1lN9tHQHdAKcnBo"
+        }
+      }
+    ],
+    "authentication": [
+      "did:trail:org:acme-corp-eu-94b549601e80458e#key-1"
+    ],
+    "assertionMethod": [
+      "did:trail:org:acme-corp-eu-94b549601e80458e#key-1"
+    ],
+    "trail:trailMode": "org",
+    "trail:supportedCryptosuites": [
+      "eddsa-jcs-2023"
+    ],
+    "trail:specVersion": "1.1.0",
+    "service": [
+      {
+        "id": "did:trail:org:acme-corp-eu-94b549601e80458e#trail-registry",
+        "type": "TrailRegistryService",
+        "serviceEndpoint": "https://registry.trailprotocol.org/1.0/identifiers/did:trail:org:acme-corp-eu-94b549601e80458e"
+      }
+    ],
+    "alsoKnownAs": [
+      "did:trail:org:acme-web-agent-1b2641281557b5c4"
+    ]
+  },
+  "foreignDidDocument": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://trailprotocol.org/ns/did/v1"
+    ],
+    "id": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+    "verificationMethod": [
+      {
+        "id": "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1",
+        "type": "JsonWebKey2020",
+        "controller": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+        "publicKeyJwk": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "DDEI6DMMWDfHs9x4ACNGe9TY9kZbRL_yAwq7d_PLYbo"
+        }
+      }
+    ],
+    "authentication": [
+      "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1"
+    ],
+    "assertionMethod": [
+      "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1"
+    ],
+    "trail:trailMode": "org",
+    "trail:supportedCryptosuites": [
+      "eddsa-jcs-2023"
+    ],
+    "trail:specVersion": "1.1.0",
+    "service": [
+      {
+        "id": "did:trail:org:acme-web-agent-1b2641281557b5c4#trail-registry",
+        "type": "TrailRegistryService",
+        "serviceEndpoint": "https://registry.trailprotocol.org/1.0/identifiers/did:trail:org:acme-web-agent-1b2641281557b5c4"
+      }
+    ],
+    "alsoKnownAs": [
+      "did:trail:org:acme-corp-eu-94b549601e80458e"
+    ]
+  },
+  "trailCredential": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://trailprotocol.org/ns/credentials/v2"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "BindingProofCredential"
+    ],
+    "issuer": "did:trail:org:acme-corp-eu-94b549601e80458e",
+    "validFrom": "2026-06-15T00:00:00Z",
+    "validUntil": "2027-06-15T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+      "binding": {
+        "from": "did:trail:org:acme-corp-eu-94b549601e80458e",
+        "to": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+        "boundAt": "2026-06-15T00:00:00Z"
+      }
+    },
+    "credentialStatus": {
+      "id": "https://registry.trailprotocol.org/1.0/status/2026-06#42",
+      "type": "StatusList2021Entry",
+      "statusPurpose": "revocation",
+      "statusListIndex": "42",
+      "statusListCredential": "https://registry.trailprotocol.org/1.0/status/2026-06"
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2023",
+      "created": "2026-07-01T05:12:08.263Z",
+      "verificationMethod": "did:trail:org:acme-corp-eu-94b549601e80458e#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z4bDpw98vxFdrLc9WteaeHEeKckyZ3Kkvbapi7C585Ypm439WJwYnFLa3LzCNJzeSb1CBkTiUYwJPB61iN4nt7fUG"
+    }
+  },
+  "foreignCredential": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://trailprotocol.org/ns/credentials/v2"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "BindingProofCredential"
+    ],
+    "issuer": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+    "validFrom": "2026-06-15T00:00:00Z",
+    "validUntil": "2027-06-15T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:trail:org:acme-corp-eu-94b549601e80458e",
+      "binding": {
+        "from": "did:trail:org:acme-web-agent-1b2641281557b5c4",
+        "to": "did:trail:org:acme-corp-eu-94b549601e80458e",
+        "boundAt": "2026-06-15T00:00:00Z"
+      }
+    },
+    "credentialStatus": {
+      "id": "https://acme-corp.eu/credentials/status/2026-06#7",
+      "type": "StatusList2021Entry",
+      "statusPurpose": "revocation",
+      "statusListIndex": "7",
+      "statusListCredential": "https://acme-corp.eu/credentials/status/2026-06"
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2023",
+      "created": "2026-07-01T05:12:08.264Z",
+      "verificationMethod": "did:trail:org:acme-web-agent-1b2641281557b5c4#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z2e77TZyH2KWKrTuPEZrcVPHdCucRz2DeNSW1MZ5ZnuWSR99iUiVHMA7swSRgucjRou3teqZ3CeWBTaeLf4bLj1Kr"
+    }
+  }
+}


### PR DESCRIPTION
Implements §5.4.5 BindingProofCredential in @trailprotocol/core, following the now-merged spec PR #22 

Adds:
- `createBindingProofCredential()` — builds one outbound leg (`from == issuer`).
- `verifyBindingProof()` — pure verifier over two resolved DID Documents + both credentials + caller-supplied revocation state. Implements all seven §5.4.5.3 steps. No network IO — resolution and StatusList fetching stay the caller's job, per the Jun 14 sequencing note.
- Types: `alsoKnownAs` on DidDocument, `StatusList2021Entry`, VC 2.0 fields on VerifiableCredential, `BindingProofCredential`.
- Tests: roundtrip + six failure modes + the §5.4.5.4 consent-limitation vector (59 tests passing).
- Test vectors in `validation/fixtures/` with real Ed25519 signatures.

Scaffolding types and BindingProof functions land together in one PR to avoid a types-only merge with no consumer (the Jun 14 note's second option).

Notes for review:
- `issuanceDate` on VerifiableCredential is now optional (VC 2.0 credentials use `validFrom`/`validUntil`). No existing caller breaks. Happy to split into a separate interface if you'd prefer strictness.
- Step 5 is scoped to "key not revoked at verification time"; the stricter "active at boundAt" check is deferred until §8.9 has a normative key-lifecycle state machine, consistent with the spec.
- Changelog: covered by the v1.3.0-draft entry in the spec's §16 (added in the spec PR); the repo has no root CHANGELOG.md.

Refs #21